### PR TITLE
Allow full brightness

### DIFF
--- a/ha_mqtt_rgb_light/ha_mqtt_rgb_light.ino
+++ b/ha_mqtt_rgb_light/ha_mqtt_rgb_light.ino
@@ -92,7 +92,7 @@ PubSubClient client(wifiClient);
 // function called to adapt the brightness and the color of the led
 void setColor(uint8_t p_red, uint8_t p_green, uint8_t p_blue) {
   // convert the brightness in % (0-100%) into a digital value (0-255)
-  uint8_t brightness = map(m_rgb_brightness, 0, 100, 0, 255);
+  uint8_t brightness = map(m_rgb_brightness, 0, 100, 0, 1023);
 
   analogWrite(RGB_LIGHT_RED_PIN, map(p_red, 0, 255, 0, brightness));
   analogWrite(RGB_LIGHT_GREEN_PIN, map(p_green, 0, 255, 0, brightness));


### PR DESCRIPTION
Since the ESP is a 10 bit PWM device, max brightness is at 1023.
[[Source](http://www.esp8266.com/wiki/doku.php?id=esp8266_gpio_pin_allocations#pwm)]