### PR TITLE
Deep sleep kicks in too early: ESP8266 is unable to publish the message

### DIFF
--- a/ha_mqtt_sensor_dht22/ha_mqtt_sensor_dht22.ino
+++ b/ha_mqtt_sensor_dht22/ha_mqtt_sensor_dht22.ino
@@ -95,6 +95,7 @@ void publishData(float p_temperature, float p_humidity) {
   char data[200];
   root.printTo(data, root.measureLength() + 1);
   client.publish(MQTT_SENSOR_TOPIC, data, true);
+  yield();
 }
 
 // function called when a MQTT message arrived


### PR DESCRIPTION

Without the additional yield my MQTT broken doesn't receive any message of the ESP8266. The WiFi stack needs some time to deliver the message before going to deep sleep. 
