### PR TITLE
Add missing quotation marks to HA configuration

### DIFF
--- a/ha_mqtt_light/README.md
+++ b/ha_mqtt_light/README.md
@@ -6,7 +6,7 @@ configuration.yaml :
 ```yaml
 light:
   platform: mqtt
-  name: Office light'
+  name: 'Office light'
   state_topic: 'office/light1/status'
   command_topic: 'office/light1/switch'
   optimistic: false


### PR DESCRIPTION
There was a missing quotation mark on basic light example, that might break the HA configuration.