### PR TITLE
Fix INFO logging with line break

### DIFF
--- a/ha_mqtt_binary_sensor_pir/ha_mqtt_binary_sensor_pir.ino
+++ b/ha_mqtt_binary_sensor_pir/ha_mqtt_binary_sensor_pir.ino
@@ -80,7 +80,7 @@ void callback(char* p_topic, byte* p_payload, unsigned int p_length) {
 void reconnect() {
   // Loop until we're reconnected
   while (!client.connected()) {
-    Serial.print("INFO: Attempting MQTT connection...");
+    Serial.println("INFO: Attempting MQTT connection...");
     // Attempt to connect
     if (client.connect(MQTT_CLIENT_ID, MQTT_USER, MQTT_PASSWORD)) {
       Serial.println("INFO: connected");

--- a/ha_mqtt_light/ha_mqtt_light.ino
+++ b/ha_mqtt_light/ha_mqtt_light.ino
@@ -108,7 +108,7 @@ void callback(char* p_topic, byte* p_payload, unsigned int p_length) {
 void reconnect() {
   // Loop until we're reconnected
   while (!client.connected()) {
-    Serial.print("INFO: Attempting MQTT connection...");
+    Serial.println("INFO: Attempting MQTT connection...");
     // Attempt to connect
     if (client.connect(MQTT_CLIENT_ID, MQTT_USER, MQTT_PASSWORD)) {
       Serial.println("INFO: connected");

--- a/ha_mqtt_light_with_brightness/ha_mqtt_light_with_brightness.ino
+++ b/ha_mqtt_light_with_brightness/ha_mqtt_light_with_brightness.ino
@@ -136,7 +136,7 @@ void callback(char* p_topic, byte* p_payload, unsigned int p_length) {
 void reconnect() {
   // Loop until we're reconnected
   while (!client.connected()) {
-    Serial.print("INFO: Attempting MQTT connection...");
+    Serial.println("INFO: Attempting MQTT connection...");
     // Attempt to connect
     if (client.connect(MQTT_CLIENT_ID, MQTT_USER, MQTT_PASSWORD)) {
       Serial.println("\nINFO: connected");

--- a/ha_mqtt_rgb_light/ha_mqtt_rgb_light.ino
+++ b/ha_mqtt_rgb_light/ha_mqtt_rgb_light.ino
@@ -187,7 +187,7 @@ void callback(char* p_topic, byte* p_payload, unsigned int p_length) {
 void reconnect() {
   // Loop until we're reconnected
   while (!client.connected()) {
-    Serial.print("INFO: Attempting MQTT connection...");
+    Serial.println("INFO: Attempting MQTT connection...");
     // Attempt to connect
     if (client.connect(MQTT_CLIENT_ID, MQTT_USER, MQTT_PASSWORD)) {
       Serial.println("INFO: connected");

--- a/ha_mqtt_sensor_dht22/ha_mqtt_sensor_dht22.ino
+++ b/ha_mqtt_sensor_dht22/ha_mqtt_sensor_dht22.ino
@@ -105,7 +105,7 @@ void callback(char* p_topic, byte* p_payload, unsigned int p_length) {
 void reconnect() {
   // Loop until we're reconnected
   while (!client.connected()) {
-    Serial.print("INFO: Attempting MQTT connection...");
+    Serial.println("INFO: Attempting MQTT connection...");
     // Attempt to connect
     if (client.connect(MQTT_CLIENT_ID, MQTT_USER, MQTT_PASSWORD)) {
       Serial.println("INFO: connected");

--- a/ha_mqtt_switch/ha_mqtt_switch.ino
+++ b/ha_mqtt_switch/ha_mqtt_switch.ino
@@ -114,7 +114,7 @@ void callback(char* p_topic, byte* p_payload, unsigned int p_length) {
 void reconnect() {
   // Loop until we're reconnected
   while (!client.connected()) {
-    Serial.print("INFO: Attempting MQTT connection...");
+    Serial.println("INFO: Attempting MQTT connection...");
     // Attempt to connect
     if (client.connect(MQTT_CLIENT_ID, MQTT_USER, MQTT_PASSWORD)) {
       Serial.println("INFO: connected");


### PR DESCRIPTION
Silly change to break line after `INFO: Attempting MQTT connection...` message. Some places had, some places didn't. Now, everywhere we add a line break.